### PR TITLE
feat: Redis 기반 ratelimit구현

### DIFF
--- a/api-gateway-server/src/main/java/com/synapse/api_gateway_server/ApiGatewayServerApplication.java
+++ b/api-gateway-server/src/main/java/com/synapse/api_gateway_server/ApiGatewayServerApplication.java
@@ -3,7 +3,9 @@ package com.synapse.api_gateway_server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@SpringBootApplication
+@SpringBootApplication(excludeName = {
+	"org.springframework.cloud.gateway.config.GatewayRedisAutoConfiguration"
+})
 public class ApiGatewayServerApplication {
 
 	public static void main(String[] args) {

--- a/api-gateway-server/src/main/java/com/synapse/api_gateway_server/configuration/RateLimiterConfig.java
+++ b/api-gateway-server/src/main/java/com/synapse/api_gateway_server/configuration/RateLimiterConfig.java
@@ -1,0 +1,38 @@
+package com.synapse.api_gateway_server.configuration;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.scripting.support.ResourceScriptSource;
+
+import com.synapse.api_gateway_server.ratelimit.limit.CustomRedisRateLimiter;
+import com.synapse.api_gateway_server.ratelimit.limit.RateLimiter;
+
+@Configuration
+public class RateLimiterConfig {
+    @Bean
+    public RateLimiter RateLimiter(
+        ReactiveStringRedisTemplate redisTemplate,
+        RedisScript<List<Long>> redisScript
+    ) {
+        return new CustomRedisRateLimiter(redisTemplate, redisScript);
+    }
+
+    @Bean
+    @SuppressWarnings("unchecked")
+    public RedisScript<List<Long>> customRedisRequestRateLimiterScript() {
+        DefaultRedisScript<List<Long>> redisScript = new DefaultRedisScript<>();
+        ClassPathResource resource = new ClassPathResource("script/rate_limiter.lua");
+        if (!resource.exists()) {
+            throw new IllegalArgumentException("script/rate_limiter.lua not found");
+        }
+        redisScript.setScriptSource(new ResourceScriptSource(resource));
+        redisScript.setResultType((Class<List<Long>>) (Class<?>) List.class);
+        return redisScript;
+    }
+}

--- a/api-gateway-server/src/main/java/com/synapse/api_gateway_server/dto/RateLimitPolicy.java
+++ b/api-gateway-server/src/main/java/com/synapse/api_gateway_server/dto/RateLimitPolicy.java
@@ -1,0 +1,13 @@
+package com.synapse.api_gateway_server.dto;
+
+public record RateLimitPolicy(
+    long replenishRate,
+    long burstCapacity,
+    long requestedTokens,
+    long maxTotalRequests,
+    long totalRequestsTtlSeconds
+) {
+    public RateLimitPolicy(long replenishRate, long burstCapacity, long maxTotalRequests, long totalRequestsTtlSeconds) {
+        this(replenishRate, burstCapacity, 1, maxTotalRequests, totalRequestsTtlSeconds);
+    }
+}

--- a/api-gateway-server/src/main/java/com/synapse/api_gateway_server/dto/RateLimitResponse.java
+++ b/api-gateway-server/src/main/java/com/synapse/api_gateway_server/dto/RateLimitResponse.java
@@ -1,0 +1,11 @@
+package com.synapse.api_gateway_server.dto;
+
+public record RateLimitResponse(
+    long tokensLeft,
+    long totalRequests,
+    RateLimitPolicy policy
+) {
+    public static RateLimitResponse from(long tokensLeft, long totalRequests, RateLimitPolicy policy) {
+        return new RateLimitResponse(tokensLeft, totalRequests, policy);
+    }
+}

--- a/api-gateway-server/src/main/java/com/synapse/api_gateway_server/exception/GlobalRateLimitException.java
+++ b/api-gateway-server/src/main/java/com/synapse/api_gateway_server/exception/GlobalRateLimitException.java
@@ -1,7 +1,15 @@
 package com.synapse.api_gateway_server.exception;
 
+import lombok.Getter;
+
+@Getter
 public class GlobalRateLimitException extends AbstractGatewayException {
-    public GlobalRateLimitException() {
-        super(ExceptionType.GLOBAL_RATE_LIMIT_EXCEEDED);
+    private final String message;
+    private final Throwable cause;
+
+    public GlobalRateLimitException(ExceptionType exceptionType, String message, Throwable cause) {
+        super(exceptionType);
+        this.message = message;
+        this.cause = cause;
     }
 }

--- a/api-gateway-server/src/main/java/com/synapse/api_gateway_server/ratelimit/limit/CustomRedisRateLimiter.java
+++ b/api-gateway-server/src/main/java/com/synapse/api_gateway_server/ratelimit/limit/CustomRedisRateLimiter.java
@@ -1,0 +1,67 @@
+package com.synapse.api_gateway_server.ratelimit.limit;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+
+import com.synapse.api_gateway_server.dto.RateLimitPolicy;
+import com.synapse.api_gateway_server.dto.RateLimitResponse;
+import com.synapse.api_gateway_server.exception.ExceptionType;
+import com.synapse.api_gateway_server.exception.GlobalRateLimitException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@RequiredArgsConstructor
+public class CustomRedisRateLimiter implements RateLimiter {
+
+    private final ReactiveStringRedisTemplate redisTemplate;
+    private final RedisScript<List<Long>> script;
+
+    @Override
+    public Mono<RateLimitResponse> check(String id, RateLimitPolicy policy) {
+        final List<String> keys = buildKeys(id);
+
+        final List<String> args = List.of(
+            String.valueOf(policy.replenishRate()),
+            String.valueOf(policy.burstCapacity()),
+            String.valueOf(Instant.now().getEpochSecond()),
+            String.valueOf(policy.requestedTokens()),
+            String.valueOf(policy.maxTotalRequests()),
+            String.valueOf(policy.totalRequestsTtlSeconds())
+        );
+
+        return redisTemplate.execute(script, keys, args)
+                .next() // 이 스크립트는 단 하나의 결과만 필요해 -> 공식문서와는 다르게 하나의 결과를 반환하도록 lua 스크립트를 작성하였기에 reduce 는 과함.. 결과를 반환해도 이 값이 음수인지에 따라 판단이 가능함 (물론 filter 단에서)
+                .map(results -> {
+                    Long tokensLeft = results.get(1);
+                    Long totalRequests = results.get(2);
+
+                    return RateLimitResponse.from(
+                            tokensLeft,
+                            totalRequests,
+                            policy);
+                })
+                .onErrorResume(throwable -> {
+                    log.error("Rate limit check failed for key {}: {}", keys, throwable.getMessage(), throwable);
+                    return Mono.error(new GlobalRateLimitException(
+                        ExceptionType.RATE_LIMIT_CHECK_FAILED, throwable.getMessage(),throwable)
+                    );
+                });
+    }
+
+    private List<String> buildKeys(String id) {
+        String prefix = "ratelimit:{" + id + "}"; // redis cluster를 사용하고 있다면 동일한 해시 슬롯에 할당하기 위해 {} 필요함
+
+        String tokensKey = prefix + ":tokens";
+        String timestampKey = prefix + ":timestamp";
+        String totalRequestsKey = prefix + ":total_requests";
+
+        return List.of(tokensKey, timestampKey, totalRequestsKey);
+    }
+    
+}

--- a/api-gateway-server/src/main/java/com/synapse/api_gateway_server/ratelimit/limit/RateLimiter.java
+++ b/api-gateway-server/src/main/java/com/synapse/api_gateway_server/ratelimit/limit/RateLimiter.java
@@ -1,0 +1,10 @@
+package com.synapse.api_gateway_server.ratelimit.limit;
+
+import com.synapse.api_gateway_server.dto.RateLimitPolicy;
+import com.synapse.api_gateway_server.dto.RateLimitResponse;
+
+import reactor.core.publisher.Mono;
+
+public interface RateLimiter {
+    Mono<RateLimitResponse> check(String key, RateLimitPolicy policy);
+}

--- a/api-gateway-server/src/main/resources/script/rate_limiter.lua
+++ b/api-gateway-server/src/main/resources/script/rate_limiter.lua
@@ -1,0 +1,74 @@
+-- 복제 제어 설정
+redis.replicate_commands()
+
+-- 키 정의
+local tokens_key = KEYS[1]
+local timestamp_key = KEYS[2]
+local total_requests_key = KEYS[3]  -- 총 요청 횟수를 저장할 키
+
+-- 파라미터 파싱
+local rate = tonumber(ARGV[1])
+local capacity = tonumber(ARGV[2])
+local now = tonumber(ARGV[3])
+local requested = tonumber(ARGV[4])
+local max_requests = tonumber(ARGV[5])  -- 구독자별 최대 요청 횟수
+local total_requests_ttl = tonumber(ARGV[6])
+
+-- 현재 총 요청 횟수 조회
+local total_requests = tonumber(redis.call("get", total_requests_key) or 0)
+
+-- 최대 요청 횟수 초과 체크
+if total_requests >= max_requests then
+    return {0, -1, total_requests}  -- 거부
+end
+
+-- 현재 시간 처리 (Redis 시스템 시간 폴백)
+if now == nil then
+  now = redis.call('TIME')[1]
+end
+
+-- 디버깅 로깅
+redis.log(redis.LOG_DEBUG, string.format(
+  "Rate Limiter - rate: %s, capacity: %s, now: %s, requested: %s, max_requests: %s",
+  rate, capacity, now, requested, max_requests
+))
+
+-- 현재 토큰 수 조회
+local last_tokens = tonumber(redis.call("get", tokens_key) or capacity)
+
+-- 마지막 업데이트 시간 조회
+local last_refreshed = tonumber(redis.call("get", timestamp_key) or 0)
+
+-- 토큰 보충 계산
+local delta = math.max(0, now - last_refreshed)
+local filled_tokens = math.min(capacity, last_tokens + (delta * rate))
+
+-- 요청 처리
+local allowed = filled_tokens >= requested
+local new_tokens = filled_tokens
+
+if allowed then
+  new_tokens = filled_tokens - requested
+  total_requests = redis.call("INCR", total_requests_key)
+  redis.log(redis.LOG_DEBUG, string.format(
+    "Request allowed - new_tokens: %s, requested: %s",
+    new_tokens, requested
+  ))
+else
+  redis.log(redis.LOG_DEBUG, string.format(
+    "Request denied - available: %s, requested: %s",
+    filled_tokens, requested
+  ))
+end
+
+local token_bucket_ttl = math.ceil(capacity / rate) * 2
+
+redis.call("SET", tokens_key, tokens_left, "EX", token_bucket_ttl)
+redis.call("SET", timestamp_key, now, "EX", token_bucket_ttl)
+
+if total_requests == 1 then
+  redis.call("EXPIRE", total_requests_key, total_requests_ttl)
+end
+
+-- 결과 반환
+return { allowed and 1 or 0, new_tokens, total_requests }


### PR DESCRIPTION
## 개요
Redis Lua 스크립트를 활용한 커스텀 레이트 리미터를 도입하고, 토큰 버킷 기반 제어와 구독자별 누적 요청 한도(총량제)를 함께 지원합니다. 또한 기존 RFC 9457 Problem Details 포맷과 자연스럽게 연동되도록 예외 시그니처를 개선했습니다.

## 주요 변경 사항
- 레이트 리미터 구성
  - `RateLimiterConfig`: `ReactiveStringRedisTemplate` + 커스텀 Lua 스크립트 빈 등록
  - `script/rate_limiter.lua`: 토큰 버킷 + 총 요청량 제한, TTL 관리
- 레이트 제한 로직
  - `RateLimiter` 인터페이스 도입
  - `CustomRedisRateLimiter`: Redis 스크립트 실행 및 `RateLimitResponse` 매핑
- DTO
  - `RateLimitPolicy`: 보충률/버스트/요청토큰/총요청한도/TTL
  - `RateLimitResponse`: 남은 토큰/총 요청 수/정책
- 에러 포맷
  - 기존 RFC 9457 기반 응답(`application/problem+json`)과 그대로 연계

## 왜 필요한가
- 높은 트래픽 환경에서 구독자/키 단위의 공정하고 예측 가능한 요청 제어 필요
- 총량제(구독자별 최대 요청 한도)로 남용 방지
- 표준화된 에러 응답으로 클라이언트 측 처리 용이성 향상

## 기타
- 운영 Redis가 클러스터인 경우 `{}` 키 해시태그로 동일 슬롯 고정 처리됨
- 기존 예외/에러 포맷(Problem Details)과 호환 유지